### PR TITLE
Fix preview comment in PR workflow

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,14 +1,15 @@
 name: Preview Pull Request on GitHub Pages
 
 on:
-  pull_request:
-    branches:
-      - main
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
   pages: write
   id-token: write
+  issues: write
+  pull-requests: write
 
 concurrency:
   group: 'pr-preview-${{ github.event.pull_request.number }}'
@@ -18,8 +19,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout PR code
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
@@ -32,7 +36,7 @@ jobs:
         with:
           preview: true
       - name: Comment preview URL
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         uses: actions/github-script@v7
         env:
           PREVIEW_URL: ${{ steps.deployment.outputs.page_url }}

--- a/README.md
+++ b/README.md
@@ -108,4 +108,5 @@ This repository is configured to deploy automatically to **GitHub Pages**.
 Merges to `main` publish the production site. Each pull request is
 deployed as a temporary preview so you can verify your changes before
 they go live. The workflow posts a comment on the PR with the preview
-URL for convenience.
+URL for convenience. It relies on the `pull_request_target` event so the
+action has permission to create the comment.


### PR DESCRIPTION
## Summary
- allow PR preview workflow to comment using `pull_request_target`
- mention `pull_request_target` in the README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6840138b3480832ba2817264d184974c