### PR TITLE
Improve model cache management

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,25 +72,29 @@
 						<span class="btn-icon">🔍</span>
 						<span class="btn-text">Ask AI</span>
 					</button>
-					<button type="button" id="reset-btn">
-						<span class="btn-icon">🔄</span>
-						<span class="btn-text">Reset Map</span>
-					</button>
-				</div>
-			</form>
+                                        <button type="button" id="reset-btn">
+                                                <span class="btn-icon">🔄</span>
+                                                <span class="btn-text">Reset Map</span>
+                                        </button>
+                                        <button type="button" id="clear-cache-btn">
+                                                <span class="btn-icon">🗑️</span>
+                                                <span class="btn-text">Clear Model Cache</span>
+                                        </button>
+                                </div>
+                        </form>
 			
 			<section id="message" aria-live="polite" aria-label="Query results"></section>
 		</aside>
 
-		<script type="module">
-			import { initWebLLM } from "./js/llm.js";
-			document
-				.getElementById("llm-select")
-				.addEventListener("change", (event) => {
-					const selectedModel = event.target.value;
+                <script type="module">
+                        import { initWebLLM } from "./js/llm.js";
+                        document
+                                .getElementById("llm-select")
+                                .addEventListener("change", (event) => {
+                                        const selectedModel = event.target.value;
                                         initWebLLM(selectedModel);
-				});
-		</script>
+                                });
+                </script>
 
 		<script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
 		<script type="module" src="js/main.js"></script>

--- a/js/llm.js
+++ b/js/llm.js
@@ -1,4 +1,4 @@
-import { CreateMLCEngine } from "https://esm.run/@mlc-ai/web-llm";
+import { CreateMLCEngine, deleteModelAllInfoInCache } from "https://esm.run/@mlc-ai/web-llm";
 import { updateLLMStatus, updateMessage } from "./ui.js";
 import { highlightCountries } from "./map.js";
 import { getAvailableStats, getExampleCountry, executeQuery } from "./data.js";
@@ -375,5 +375,18 @@ function createResultMessage(
 	  </div>
 	`;
 
-	return message;
+        return message;
 }
+
+export async function clearAllModelCache() {
+        for (const key of Object.keys(modelConfigs)) {
+                const modelId = modelConfigs[key].model_id;
+                try {
+                        await deleteModelAllInfoInCache(modelId);
+                } catch (err) {
+                        console.error(`Failed to clear cache for ${modelId}:`, err);
+                }
+        }
+        updateMessage("<div>✅ Model cache cleared</div>");
+}
+

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,5 +1,6 @@
 import { processQuery, resetMap } from "./main.js";
 import { highlightCountry } from "./map.js";
+import { clearAllModelCache } from "./llm.js";
 
 export function updateCountryInfo(props) {
 	const countryInfoElement = document.getElementById("country-info");
@@ -241,10 +242,16 @@ export function setupEventListeners() {
 		handleQuerySubmit();
 	});
 	
-	document.getElementById("reset-btn").addEventListener("click", resetMap);
-	document.getElementById("close-btn").addEventListener("click", () => {
-		updateCountryInfo(null);
-	});
+        document.getElementById("reset-btn").addEventListener("click", resetMap);
+        const clearCacheBtn = document.getElementById("clear-cache-btn");
+        if (clearCacheBtn) {
+                clearCacheBtn.addEventListener("click", () => {
+                        clearAllModelCache();
+                });
+        }
+        document.getElementById("close-btn").addEventListener("click", () => {
+                updateCountryInfo(null);
+        });
 
 	// Add keyboard shortcuts
 	queryInput.addEventListener("keydown", (event) => {

--- a/styles.css
+++ b/styles.css
@@ -120,6 +120,14 @@ button:disabled {
   background-color: #b45309;
 }
 
+#clear-cache-btn {
+  background-color: var(--danger-color);
+}
+
+#clear-cache-btn:hover:not(:disabled) {
+  background-color: #b91c1c;
+}
+
 #close-btn {
   background-color: var(--danger-color);
   float: right;

--- a/tests/__mocks__/webllm.js
+++ b/tests/__mocks__/webllm.js
@@ -22,9 +22,12 @@ const mockEngine = {
 };
 
 export const CreateMLCEngine = jest.fn((modelId, config) => {
-	// Store engine globally so it can be accessed in tests
-	global.mockEngine = mockEngine;
-	return Promise.resolve(mockEngine);
+        // Store engine globally so it can be accessed in tests
+        global.mockEngine = mockEngine;
+        return Promise.resolve(mockEngine);
 });
+
+export const deleteModelAllInfoInCache = jest.fn(() => Promise.resolve());
+export const hasModelInCache = jest.fn(() => Promise.resolve(true));
 
 export { mockEngine };

--- a/tests/llm.test.js
+++ b/tests/llm.test.js
@@ -2,7 +2,7 @@ import { describe, test, expect, jest, beforeEach } from "@jest/globals";
 import { mockEngine } from "./__mocks__/webllm.js";
 
 describe("LLM Module", () => {
-	let generateSQLQuery, processQuery;
+        let generateSQLQuery, processQuery, clearAllModelCache;
 
 	beforeEach(async () => {
 		jest.clearAllMocks();
@@ -54,9 +54,10 @@ describe("LLM Module", () => {
 		});
 
 		// Import the functions we want to test
-		const llmModule = await import("../js/llm.js");
-		generateSQLQuery = llmModule.generateSQLQuery;
-		processQuery = llmModule.processQuery;
+                const llmModule = await import("../js/llm.js");
+                generateSQLQuery = llmModule.generateSQLQuery;
+                processQuery = llmModule.processQuery;
+                clearAllModelCache = llmModule.clearAllModelCache;
 	});
 
 	test("should generate valid SQL query from natural language", async () => {
@@ -154,8 +155,8 @@ describe("LLM Module", () => {
 		await expect(processQuery()).resolves.not.toThrow();
 	});
 
-	test("should handle missing engine", async () => {
-		global.engine = null;
+        test("should handle missing engine", async () => {
+                global.engine = null;
 
 		// Need to keep the full DOM mock for message element
 		global.document.getElementById = jest.fn((id) => {
@@ -181,6 +182,12 @@ describe("LLM Module", () => {
 		});
 
 		// The processQuery function should handle this gracefully
-		await expect(processQuery()).resolves.not.toThrow();
-	});
+                await expect(processQuery()).resolves.not.toThrow();
+        });
+
+        test("clearAllModelCache should delete caches for all models", async () => {
+                const webllm = await import("https://esm.run/@mlc-ai/web-llm");
+                await clearAllModelCache();
+                expect(webllm.deleteModelAllInfoInCache).toHaveBeenCalled();
+        });
 });

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -8,7 +8,8 @@ jest.unstable_mockModule("../js/main.js", () => ({
 }));
 
 jest.unstable_mockModule("../js/map.js", () => ({
-	highlightCountry: jest.fn()
+        highlightCountry: jest.fn(),
+        highlightCountries: jest.fn()
 }));
 
 const { updateLLMStatus, updateCountryInfo, updateMessage, setupEventListeners } = await import("../js/ui.js");
@@ -66,8 +67,9 @@ describe("UI Module", () => {
 			"message": createMockElement("message"),
 			"query-form": createMockElement("query-form"),
 			"query-input": createMockElement("query-input"),
-			"reset-btn": createMockElement("reset-btn"),
-		};
+                        "reset-btn": createMockElement("reset-btn"),
+                        "clear-cache-btn": createMockElement("clear-cache-btn"),
+                };
 
 		// Override the global document.getElementById mock for this test
 		global.document.getElementById = jest.fn((id) => mockElements[id] || null);
@@ -341,11 +343,17 @@ describe("UI Module", () => {
 			expect(mockElements["search-btn"].addEventListener).toHaveBeenCalledWith("click", expect.any(Function));
 		});
 
-		test("should setup reset button click event listener", () => {
-			setupEventListeners();
+                test("should setup reset button click event listener", () => {
+                        setupEventListeners();
 
-			expect(mockElements["reset-btn"].addEventListener).toHaveBeenCalledWith("click", expect.any(Function));
-		});
+                        expect(mockElements["reset-btn"].addEventListener).toHaveBeenCalledWith("click", expect.any(Function));
+                });
+
+                test("should setup clear cache button click event listener", () => {
+                        setupEventListeners();
+
+                        expect(mockElements["clear-cache-btn"].addEventListener).toHaveBeenCalledWith("click", expect.any(Function));
+                });
 
 		test("should setup close button click event listener", () => {
 			setupEventListeners();


### PR DESCRIPTION
## Summary
- add a clear-cache button to the interface
- support clearing WebLLM cache via `clearAllModelCache`
- style the new cache button
- wire button into UI and tests
- update mocks and tests for cache clearing

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6841f80bc788832b80f696b1c6f43f10