### PR TITLE
Add server page preview workflow

### DIFF
--- a/.github/workflows/server-preview.yml
+++ b/.github/workflows/server-preview.yml
@@ -1,0 +1,47 @@
+---
+name: Server Page Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'index.html'
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate server page screenshot
+        run: node scripts/generate-preview.js
+
+      - name: Encode screenshot
+        id: encode
+        run: |
+          echo "base64=$(base64 -w0 preview.png)" >> $GITHUB_OUTPUT
+
+      - name: Comment on PR with preview
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## Server Page Preview
+            ![Preview](data:image/png;base64,${{ steps.encode.outputs.base64 }})
+
+      - name: Cleanup
+        run: rm -f preview.png

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Our robust CI/CD pipeline ensures only tested, quality code reaches production:
 - **Test-Dependent Deployment**: Deployment only occurs after all CI checks pass
 - **GitHub Pages**: Automatic deployment to production on successful CI runs
 - **PR Previews**: Temporary preview deployments for pull requests
+- **Server Page Preview**: Automatic screenshot posted when the server page is updated
 - **Safe Deployments**: Failed tests block deployment, ensuring stability
 
 #### Available Test Commands

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "perf:full": "node tests/performance/scripts/run-evaluation.js",
     "perf:quick": "node tests/performance/scripts/run-evaluation.js --quick",
     "perf:baseline": "node tests/performance/scripts/run-evaluation.js --baseline",
-    "perf:compare": "node tests/performance/scripts/compare-results.js"
+    "perf:compare": "node tests/performance/scripts/compare-results.js",
+    "preview:screenshot": "node scripts/generate-preview.js"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/scripts/generate-preview.js
+++ b/scripts/generate-preview.js
@@ -1,0 +1,28 @@
+import { chromium } from '@playwright/test';
+import { spawn } from 'child_process';
+import fs from 'fs';
+
+async function serve() {
+  const server = spawn('python3', ['-m', 'http.server', '8000'], {
+    stdio: 'ignore'
+  });
+  // wait for server to start
+  await new Promise(r => setTimeout(r, 3000));
+  return server;
+}
+
+async function main() {
+  const server = await serve();
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1280, height: 720 } });
+  await page.goto('http://localhost:8000/index.html');
+  await page.screenshot({ path: 'preview.png', fullPage: true });
+  await browser.close();
+  server.kill();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
+


### PR DESCRIPTION
## Summary
- add GitHub Action to capture a screenshot when the server page changes
- post the screenshot as a comment on the PR
- include a simple script for generating the screenshot with Playwright
- document the new feature in README

## Testing
- `npm run lint`
- `npm run test:unit` *(fails: Error loading map data, TypeError: map.on is not a function)*

------
https://chatgpt.com/codex/tasks/task_b_6888e4cca398832b939d1d99ed80cf66